### PR TITLE
Fix syntax in FSRM script extension list

### DIFF
--- a/FSRM Script.ps1
+++ b/FSRM Script.ps1
@@ -63,7 +63,7 @@ function Install-FSRMRansomware {
                             "*.micro",
                             "*.encrypted",
                             "*.locked",
-                            "*.crypto"
+                            "*.crypto",
                             "*_crypt",
                             "*.crinf", 
                             "*.r5a", 


### PR DESCRIPTION
## Summary
- correct the comma placement for the `"*.crypto"` pattern in the array

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_683fb1b548108321a2b3b7998cad5009